### PR TITLE
Fix 9.3 dropdown bug

### DIFF
--- a/classes/EntityList.php
+++ b/classes/EntityList.php
@@ -743,6 +743,9 @@ class EntityList extends Page {
     }
 
     protected function loadPageStyles() {
+        $this->cssFiles[] = file_exists(APP_URL_EXTMOD . 'manager/css/select2.css') ?
+            APP_URL_EXTMOD . 'manager/css/select2.css' :
+            APP_URL_EXTMOD . 'Resources/css/select2.css'; # REDCap v9.3.x moved the select2 css file
         $this->cssFiles[] = APP_URL_EXTMOD . 'manager/css/select2.css';
         $this->cssFiles[] = ExternalModules::getUrl(REDCAP_ENTITY_PREFIX, 'manager/css/entity_list.css');
 

--- a/classes/EntityList.php
+++ b/classes/EntityList.php
@@ -730,7 +730,12 @@ class EntityList extends Page {
     }
 
     protected function loadPageScripts() {
-        $this->jsFiles[] = APP_URL_EXTMOD . 'manager/js/select2.js';
+        // 9.3.? has begun migrating some files from ExternalModule/manager/ to Resources/
+        // The complicated nature of this ternary is essential due to backup pathing, realpath cannot simplify this
+        // APP_PATH_EXTMOD and APP_URL_EXTMOD are not interchangeable for their respective uses
+        $this->jsFiles[] = file_exists(APP_PATH_EXTMOD . 'manager/js/select2.js') ?
+            APP_URL_EXTMOD . 'manager/js/select2.js' :
+            APP_PATH_JS . 'select2.js';
         $this->jsFiles[] = ExternalModules::getUrl(REDCAP_ENTITY_PREFIX, 'manager/js/entity_list.js');
         $this->jsFiles[] = ExternalModules::getUrl(REDCAP_ENTITY_PREFIX, 'manager/js/entity_fields.js');
 
@@ -743,9 +748,9 @@ class EntityList extends Page {
     }
 
     protected function loadPageStyles() {
-        $this->cssFiles[] = file_exists(APP_URL_EXTMOD . 'manager/css/select2.css') ?
+        $this->cssFiles[] = file_exists(APP_PATH_EXTMOD . 'manager/css/select2.css') ?
             APP_URL_EXTMOD . 'manager/css/select2.css' :
-            APP_PATH_WEBROOT . 'Resources/css/select2.css'; # REDCap v9.3.x moved the select2 css file
+            APP_PATH_CSS . 'select2.css';
         $this->cssFiles[] = ExternalModules::getUrl(REDCAP_ENTITY_PREFIX, 'manager/css/entity_list.css');
 
         parent::loadPageStyles();

--- a/classes/EntityList.php
+++ b/classes/EntityList.php
@@ -745,8 +745,7 @@ class EntityList extends Page {
     protected function loadPageStyles() {
         $this->cssFiles[] = file_exists(APP_URL_EXTMOD . 'manager/css/select2.css') ?
             APP_URL_EXTMOD . 'manager/css/select2.css' :
-            APP_URL_EXTMOD . 'Resources/css/select2.css'; # REDCap v9.3.x moved the select2 css file
-        $this->cssFiles[] = APP_URL_EXTMOD . 'manager/css/select2.css';
+            APP_PATH_WEBROOT . 'Resources/css/select2.css'; # REDCap v9.3.x moved the select2 css file
         $this->cssFiles[] = ExternalModules::getUrl(REDCAP_ENTITY_PREFIX, 'manager/css/entity_list.css');
 
         parent::loadPageStyles();


### PR DESCRIPTION
Addresses issue #12
Solution should be backwards compatible, please test on a < v9.3.0 REDCap instance.

This PR may fall under the `hotfix` category of the git flow philosophy, luckily it does not depend on any other `develop` only commit.

To test:  
Access any page built by Entity which presents a searchable list (e.g. Project Ownership's Project Owners page or OnCore Client's OnCore API Logs page). Observe that the rendering error observed in the screenshots of #12 do not occur) and dropdown menus are searchable and functional.