### PR TITLE
swap user_info for row[key] when parsing emails

### DIFF
--- a/classes/EntityList.php
+++ b/classes/EntityList.php
@@ -544,7 +544,7 @@ class EntityList extends Page {
 
                 case 'email':
                     if ($row[$key]) {
-                        $row[$key] = RCView::a(['href' => 'mailto:' . $user_info['user_email']], $row[$key]);
+                        $row[$key] = RCView::a(['href' => 'mailto:' . $row[$key]], $row[$key]);
                     }
 
                     break;


### PR DESCRIPTION
Addresses issue #11 

To test:

  1. You will need to checkout an older version of `Project Ownership`, in the root directory for your `project_ownership` module on the `develop` branch: `git checkout 00f82ba9aceeaa903567499d7567701737b2b561` (one commit prior to the alteration mentioned in the issue).
  1. Assign a project owner to any project if you have not already
  1. Navigate to the project ownership plugin page.
  1. Observe that the `mailto` property of the `Owner email` field matches the email displayed rather than being left blank.