### PR TITLE
forms involving records no longer fail as proper scope is used

### DIFF
--- a/classes/EntityForm.php
+++ b/classes/EntityForm.php
@@ -175,7 +175,7 @@ class EntityForm extends Page {
             }
             elseif ($info['type'] == 'record') {
                 if (defined('PROJECT_ID')) {
-                    $info['choices'] = Records::getRecordsAsArray(PROJECT_ID);
+                    $info['choices'] = \Records::getRecordsAsArray(PROJECT_ID);
                 }
             }
             elseif ($info['type'] == 'project') {


### PR DESCRIPTION
Prior to this, any `EntityList` that contained `type` `record` which allowed editing of rows would crash when attempting to click the edit link. The cause was the namespace of the `Records` class in REDCap.

PR is against master because this is a hotfix.