### PR TITLE
re-encode JSON data as JSON string so it will actually show in the form

### DIFF
--- a/classes/EntityForm.php
+++ b/classes/EntityForm.php
@@ -136,7 +136,7 @@ class EntityForm extends Page {
             }
 
             // convert JSON back to a string for proper display in fields
-            if ($info['type'] == 'json') {
+            if ($info['type'] == 'json' && $data[$key] !== NULL) {
                 $data[$key] = json_encode($data[$key], JSON_PRETTY_PRINT);
             }
 

--- a/classes/EntityForm.php
+++ b/classes/EntityForm.php
@@ -135,6 +135,11 @@ class EntityForm extends Page {
                 }
             }
 
+            // convert JSON back to a string for proper display in fields
+            if ($info['type'] == 'json') {
+                $data[$key] = json_encode($data[$key], JSON_PRETTY_PRINT);
+            }
+
             $data[$key] = REDCap::escapeHtml($data[$key]);
 
             $attrs = ['name' => $key, 'class' => 'form-control', 'id' => 'redcap-entity-prop-' . $key];


### PR DESCRIPTION
Addresses issue #23 

Testing will be easiest by using [this PR to `fr_covidata`](https://github.com/ctsit/fr_covidata/pull/18) that implements a JSON field. You may want to comment out the loading of a bit of JavaScript that fills in a template of JSON data on `classes/entity/form/TestSiteForm.php::17`.

To test:

1. Load the above PR
1. comment out the mentioned line in the `fr_covidata` PR
1. Navigate to the "Define Sites" menu and edit an existing site (create one if necessary)
1. Enter data into the "Custom week" field
1. Save
1. Return to edit the same site
1. observe that with **this** PR loaded the field shows the data entered (without this PR it would appear blank even though there _is_ data)

Suggested JSON to insert into the "Custom week" field while testing:  
```json
{
    "Monday": {
        "open": "13:00",
        "close": "18:00"
    },
    "Tuesday": {
        "open": "",
        "close": ""
    },
    "Wednesday": {
        "open": "13:00",
        "close": "18:00"
    },
    "Thursday": {
        "open": "",
        "close": ""
    },
    "Friday": {
        "open": "13:00",
        "close": "18:00"
    },
    "Saturday": {
        "open": "",
        "close": ""
    },
    "Sunday": {
        "open": "",
        "close": ""
    }
}
```