### PR TITLE
adds and implements checkCsrfToken in SchemaManagerPage to eliminate CSRF vulnerability

### DIFF
--- a/classes/SchemaManagerPage.php
+++ b/classes/SchemaManagerPage.php
@@ -14,6 +14,7 @@ class SchemaManagerPage extends Page {
 
         if (
             $_SERVER['REQUEST_METHOD'] == 'POST' &&
+            $this->checkCsrfToken() &&
             !empty($_POST['entity_type']) &&
             !empty($_POST['operation']) &&
             in_array($_POST['operation'], ['build', 'drop']) &&
@@ -159,5 +160,18 @@ class SchemaManagerPage extends Page {
     protected function loadTemplate($template, $vars = []) {
         extract($vars);
         include dirname(__DIR__) . '/templates/' . $template . '.php';
+    }
+
+    protected function checkCsrfToken() {
+        /* REDCap core considers External Module pages exempt from usual CSRF checks
+         * See: checkCsrfToken in Classes/System.php
+         */
+        if (!empty($_REQUEST['redcap_csrf_token'])) {
+            // below function call is void but calls exit on failure
+            \System::forceCsrfTokenCheck($_REQUEST['redcap_csrf_token']);
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Closes #30 

To test:

## Setup
1. Spin up a server with redcap_entity and project_ownership (or any other module which uses entity) enabled
1. If needed, initialize the project_ownership table
   - Control Center > Entity DB Manager (bottom of left bar) > create db table
1. Save a local `html` file using the example page in the issue
   -  Change `REDCapServer` to your local host, e.g. (`http://localhost:11051/redcap_v10.5.1`)
   - Change the arg for `entity_type` from `project_ownership` if needed.
1. Use phpmyadmin to dump your `project_ownership` table if it's populated

## Testing
1. Open the local html file in a separate window
1. Reload your Entity DB Manager page and observe the table was dropped/unaffected